### PR TITLE
Flekschas/speed optimizations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cooler==0.7.4
 Cython==0.25.2
 django-cors-headers==1.3.1
 django-guardian==1.4.6
@@ -11,5 +12,3 @@ requests==2.12.3
 slugid==1.0.7
 bumpversion==0.5.3
 redis==2.10.5
-
--e git://github.com/mirnylab/cooler@develop#egg=cooler

--- a/tilesets/tiles.py
+++ b/tilesets/tiles.py
@@ -16,7 +16,6 @@ def make_tile(zoomLevel, x_pos, y_pos, dset):
     start2 = y_pos * info['max_width'] / divisor
     end2 = (y_pos + 1) * info['max_width'] / divisor
 
-    #print(start1, end1-1, start2, end2-1)
     data = cch.get_data(
         dset[0], zoomLevel, start1, end1 - 1, start2, end2 - 1
     )
@@ -32,14 +31,8 @@ def make_tile(zoomLevel, x_pos, y_pos, dset):
     else:
         v = np.nan_to_num(df['count'].values)
 
-    zi = zip(zip(i, j), v)
-    tile_bins = dict(zi)
-    denseOutputArray = []
-    for i in range(0, 256):
-        for j in range(0, 256):
-            if (i, j) in tile_bins:
-                denseOutputArray.append(tile_bins[(i, j)])
-            else:
-                denseOutputArray.append(0)
+    out = np.zeros(65536, dtype=np.float32)  # 256^2
+    index = (i * 256) + j
+    out[index] = v
 
-    return np.array(denseOutputArray, dtype=np.float32)
+    return out


### PR DESCRIPTION
Speed up fragment / snippet / patch extraction by about 50% and speed up tile making by around 50-70ms. This is achieved by replacing python loops with Numpy vector operations, which are blazing fast.
Tile retrieval is furthermore sped up by including the latest version of cooler.