### PR TITLE
Flekschas/improved fragment retrieval

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v0.7.5 (2017-07-07)
+
+- Improved performance of fragment retrieval for lower resolutions
+- Retrieve mirrored matrix (and not just the upper triangle)
+
 v0.7.4 (2017-06-20)
 
 - Added ordering to tileset list API


### PR DESCRIPTION
1. Speed up snippet retrieval by pre-fetching chromosomes up to a 4KB (for higher resolutions fetching the entire chromosome gets slow)
2. Improve retrieved snippets by returning the full matrix (and not just the upper triangular matrix)