### PR TITLE
Flekschas/cooler chromsizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.5.0 (2017-11-??)
+
+- Added support for cooler-based chrom-sizes retrieval
+
 v1.4.2 (2017-11-13)
 
 - Fixed issue where bigWig files weren't being found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-v1.3.0 (2017-10-xx)
+v1.3.1 (2017-10-??)
+
+- Fixed a bug with ignore-diags in the fragments API (again)
+
+v1.3.0 (2017-10-21)
 
 - Support arbitrary resolution cooler files
 - Combine tile requests for beddb and bed2ddb files
@@ -9,7 +13,7 @@ v1.2.3 (2017-10-03)
 - Same changes as last time. They didn't actually make it into v1.2.2
 v1.2.2 (2017-10-03)
 
-- Fixed a bug with ignore-diags int the fragments API
+- Fixed a bug with ignore-diags in the fragments API
 
 v1.2.1 (2017-08-30)
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Genomics data needs to be aggregated across a range of scales before it can be u
 **TODO**: Is this still accurate?
 
 [Cooler](https://github.com/mirnylab/cooler) files store Hi-C data. They need to be decorated with aggregated
-data at multiple resolutions in order to work with `higlass-server`. This is easily accomplished by simply 
-installing the `cooler` python package and running the `recursive_agg_onefile.py` script. For now this has 
+data at multiple resolutions in order to work with `higlass-server`. This is easily accomplished by simply
+installing the `cooler` python package and running the `recursive_agg_onefile.py` script. For now this has
 to come from a clone of the official cooler repository, but this will hopefully be merged into the main branch shortly.
 
 ```
@@ -105,4 +105,10 @@ npm test
 
 ```
 bumpversion patch
+```
+
+**Update** source code:
+
+```
+./update.sh
 ```

--- a/README.md
+++ b/README.md
@@ -112,3 +112,7 @@ bumpversion patch
 ```
 ./update.sh
 ```
+
+## Troubleshooting
+
+**pybbi installation fails on macOS**: Check out https://github.com/nvictus/pybbi/issues/2

--- a/tilesets/tests.py
+++ b/tilesets/tests.py
@@ -80,6 +80,52 @@ class ChromosomeSizes(dt.TestCase):
         assert(ret.status_code == 200)
         assert('chr1' in data)
 
+        ret = self.client.get(
+            '/api/v1/chrom-sizes/?id=cs-hg19&type=json&cum=1'
+        )
+
+        data = json.loads(ret.content.decode('utf-8'))
+        assert(ret.status_code == 200)
+        assert('offset' in data['chr1'])
+
+    def test_chromsizes_from_cooler(self):
+        self.user1 = dcam.User.objects.create_user(
+            username='user1', password='pass'
+        )
+        upload_file = open(
+            'data/dixon2012-h1hesc-hindiii-allreps-filtered.1000kb.multires.cool',
+            'rb'
+        )
+        self.chroms = tm.Tileset.objects.create(
+            datafile=dcfu.SimpleUploadedFile(
+                upload_file.name, upload_file.read()
+            ),
+            filetype='cooler',
+            datatype='matrix',
+            coordSystem='hg19',
+            owner=self.user1,
+            uuid='cooler-dixon'
+        )
+
+        ret = self.client.get('/api/v1/chrom-sizes/?id=cooler-dixon')
+
+        assert(ret.status_code == 200)
+        assert(len(ret.content) > 300)
+
+        ret = self.client.get('/api/v1/chrom-sizes/?id=cooler-dixon&type=json')
+
+        data = json.loads(ret.content.decode('utf-8'))
+        assert(ret.status_code == 200)
+        assert('chr1' in data)
+
+        ret = self.client.get(
+            '/api/v1/chrom-sizes/?id=cooler-dixon&type=json&cum=1'
+        )
+
+        data = json.loads(ret.content.decode('utf-8'))
+        assert(ret.status_code == 200)
+        assert('offset' in data['chr1'])
+
 
 class TilesetModelTest(dt.TestCase):
     def test_to_string(self):

--- a/tilesets/views.py
+++ b/tilesets/views.py
@@ -53,6 +53,7 @@ from rest_framework.authentication import BasicAuthentication
 from fragments.drf_disable_csrf import CsrfExemptSessionAuthentication
 
 from higlass_server.utils import getRdb
+from fragments.utils import get_cooler
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,7 @@ def uids_by_filename(request):
     serializer = tss.UserFacingTilesetSerializer(queryset, many=True)
 
     return JsonResponse({"count": len(queryset), "results": serializer.data})
+
 
 @api_view(['GET'])
 @authentication_classes((CsrfExemptSessionAuthentication, BasicAuthentication))
@@ -111,7 +113,7 @@ def sizes(request):
             queries:
 
             id: id of the stored chromSizes [e.g.: hg19 or mm9]
-            type: return data format [tsv or json]
+            type: return data format [csv, tsv, or json]
             cum: return cumulative size or offset [0 or 1]
 
     Returns:
@@ -161,7 +163,7 @@ def sizes(request):
         chrom_sizes = tm.Tileset.objects.get(uuid=uuid)
     except Exception as e:
         logger.error(e)
-        err_msg = 'Oh lord! ChromSizes for %s not found. ☹️' % uuid
+        err_msg = 'Oh lord! ChromSizes for %s not found. 😬' % uuid
         err_status = 404
 
         if is_json:
@@ -170,31 +172,63 @@ def sizes(request):
         return response(err_msg, status=err_status)
 
     # Try to load the CSV file
-    try:
-        f = chrom_sizes.datafile
-        f.open('r')
+    if chrom_sizes.datatype == 'matrix':
+        with h5py.File(chrom_sizes.datafile.url, 'r') as f:
 
-        if res_type == 'json':
-            reader = csv.reader(f, delimiter='\t')
+            try:
+                c = get_cooler(f)
+            except Exception as e:
+                logger.error(e)
+                err_msg = 'Yikes... Couldn~\'t init them cooler files 😵'
+                err_status = 500
 
-            data = []
-            for row in reader:
-                data.append(row)
-        else:
-            data = f.readlines()
+                if is_json:
+                    return response({'error': err_msg}, status=err_status)
 
-        f.close()
-    except Exception as e:
-        logger.error(e)
-        err_msg = 'WHAT?! Could not load file %s. 😤 (%s)' % (
-            chrom_sizes.datafile, e
-        )
-        err_status = 500
+                return response(err_msg, status=err_status)
 
-        if is_json:
-            return response({'error': err_msg}, status=err_status)
+            try:
+                if res_type == 'csv':
+                    data = c.chromsizes.to_csv()
+                elif res_type == 'tsv':
+                    data = c.chromsizes.to_csv(sep='\t')
+                else:
+                    data = []
+                    for chrom, size in c.chromsizes.iteritems():
+                        data.append([chrom, size])
+            except Exception as e:
+                logger.error(e)
+                err_msg = 'Them cooler files has no `chromsizes` attribute 🤔'
+                err_status = 500
 
-        return response(err_msg, status=err_status)
+                if is_json:
+                    return response({'error': err_msg}, status=err_status)
+
+                return response(err_msg, status=err_status)
+
+    else:
+        try:
+            with open(chrom_sizes.datafile, 'r') as f:
+                if res_type == 'json':
+                    reader = csv.reader(f, delimiter='\t')
+
+                    data = []
+                    for row in reader:
+                        data.append(row)
+                else:
+                    data = f.readlines()
+
+        except Exception as e:
+            logger.error(e)
+            err_msg = 'WHAT?! Could not load file %s. 😤 (%s)' % (
+                chrom_sizes.datafile, e
+            )
+            err_status = 500
+
+            if is_json:
+                return response({'error': err_msg}, status=err_status)
+
+            return response(err_msg, status=err_status)
 
     # Convert the stuff if needed
     try:
@@ -280,7 +314,7 @@ def viewconfs(request):
                 'error': 'Public uploads disabled'
             }, status=403)
 
-        viewconf_wrapper = json.loads(request.body)
+        viewconf_wrapper = json.loads(request.body.decode('utf-8'))
         uid = viewconf_wrapper.get('uid') or slugid.nice().decode('utf-8')
 
         try:
@@ -324,7 +358,7 @@ def viewconfs(request):
 
     return JsonResponse(json.loads(obj.viewconf))
 
-def add_transform_type(tile_id): 
+def add_transform_type(tile_id):
     '''
     Add a transform type to a cooler tile id if it's not already
     present.

--- a/tilesets/views.py
+++ b/tilesets/views.py
@@ -208,7 +208,7 @@ def sizes(request):
 
     else:
         try:
-            with open(chrom_sizes.datafile, 'r') as f:
+            with open(chrom_sizes.datafile.url, 'r') as f:
                 if res_type == 'json':
                     reader = csv.reader(f, delimiter='\t')
 

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+git pull
+
+pip install -r ./requirements.txt
+
+pip install -r ./requirements-secondary.txt
+
+python manage.py migrate


### PR DESCRIPTION
- Enable pulling chrom-sizes from cooler files. API does not change so `/api/v1/chrom-sizes/?id=<UUID-OF-COOLER-TILESET>&type=json&cum=1` just works.
- Add a test for the expanded API
- Robustify existing chrom-sizes test
- Fix UTF-8 decoding issues in Python 3.5
